### PR TITLE
Fix logs cleanup function

### DIFF
--- a/logs.py
+++ b/logs.py
@@ -1,6 +1,9 @@
 from loguru import logger
 import time
 import sys
+import re
+
+brackets_regex = re.compile(r'<.*?>')
 
 def logging_setup():
 
@@ -22,8 +25,5 @@ def logging_setup():
 def clean_brackets(raw_str):
     clean_text = re.sub(brackets_regex, '', raw_str)
     return clean_text
-
-
-# brackets_regex = re.compile(r'<.*?>')
 
 logging_setup()


### PR DESCRIPTION
## Summary
- import `re` and compile regex for removing brackets
- keep `logging_setup()` active

## Testing
- `python3 -m py_compile logs.py`


------
https://chatgpt.com/codex/tasks/task_e_684e08a671d48324a797e1fdf1d2abee