### PR TITLE
Make arbitrage calculations non-blocking

### DIFF
--- a/arbitrage.py
+++ b/arbitrage.py
@@ -145,9 +145,9 @@ async def main():
         try:
 
             stime = time.time()
-            combinations = create_combinations(pools, 1)
+            combinations = await asyncio.to_thread(create_combinations, pools, 1)
 
-            arbitrages = find_arbitrage(combinations, pools)
+            arbitrages = await asyncio.to_thread(find_arbitrage, combinations, pools)
 
             swapped = False
             for arbitrage in arbitrages:


### PR DESCRIPTION
## Summary
- move heavy calculations for combinations and arbitrage detection off the event loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e087622bc8324867ea4a46cb9a550