### PR TITLE
Fix duplicate start function in arbitrage

### DIFF
--- a/arbitrage.py
+++ b/arbitrage.py
@@ -197,18 +197,6 @@ async def main():
 def start():
     threading.Thread(target=send_msg, daemon=True).start()
     asyncio.run(main())
-                                logger.warning(f"ожидаем подтверждение транзакции {txId} | {tx}")
-                                await asyncio.sleep(tx_poll_interval)
-
-                        swapped = True
-            # break
-        except Exception as err:
-            logger.error([err, extract_tb(exc_info()[2])])
-            await asyncio.sleep(3)
-
-def start():
-    threading.Thread(target=send_msg, daemon=True).start()
-    asyncio.run(main())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- remove stray duplicate block and redundant `start()` definition
- keep single `start()` function for arbitrage script

## Testing
- `python -m py_compile arbitrage.py`

------
https://chatgpt.com/codex/tasks/task_e_684e0ec4f8348324baa1d572c34f6408