### PR TITLE
Fix imports and add exchange info support

### DIFF
--- a/misc.py
+++ b/misc.py
@@ -7,6 +7,18 @@ import time
 import Settings
 import requests
 from logs import logger
+import trading_api
+
+try:
+    import adds_api
+except ImportError:  # fallback if optional module is missing
+    class adds_api:
+        @staticmethod
+        def get_adds():
+            return ""
+
+# Default informational text for signals
+info_signal = ""
 
 def getSymbols():
     symbols = ["-"]

--- a/trading_api.py
+++ b/trading_api.py
@@ -203,6 +203,40 @@ async def get_pools_async():
 def get_pools():
     return asyncio.run(get_pools_async())
 
+
+def get_exchange_information():
+    """Return simplified exchange information based on available pools."""
+    res = requests.get(host + "/hamster/get_pools").json()["result"]
+
+    symbols = []
+    for r in res:
+        base = r["coin0"]["symbol"]
+        quote = r["coin1"]["symbol"]
+
+        common_filters = [
+            {"filterType": "LOT_SIZE", "minQty": "1"},
+            {"filterType": "PRICE_FILTER", "tickSize": "0.00000001"},
+            {"filterType": "MARKET_LOT_SIZE", "minQty": "1"},
+        ]
+
+        symbols.append({
+            "symbol": f"{base}/{quote}",
+            "status": "TRADING",
+            "baseAsset": base,
+            "quoteAsset": quote,
+            "filters": common_filters,
+        })
+
+        symbols.append({
+            "symbol": f"{quote}/{base}",
+            "status": "TRADING",
+            "baseAsset": quote,
+            "quoteAsset": base,
+            "filters": common_filters,
+        })
+
+    return {"symbols": symbols}
+
 async def pools_ws():
     url = ws_host + "/hamster/pools/ws"
     while True:


### PR DESCRIPTION
## Summary
- add missing `trading_api` import in `misc.py`
- provide fallbacks for optional `adds_api` module and `info_signal`
- implement simplified `get_exchange_information()` in `trading_api`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684e11e554b08324869a5ec107ef920f