### PR TITLE
Fix save_data writing wrong variable

### DIFF
--- a/Settings.py
+++ b/Settings.py
@@ -25,7 +25,7 @@ def saveLog(log):
 
 def save_data(data):
     f = open(f"data.txt", "w")
-    f.write(str(couples))
+    f.write(str(data))
     f.close()
 
 def get_data():


### PR DESCRIPTION
## Summary
- correct typo in `save_data` so that it stores the provided argument

## Testing
- `python -m py_compile Settings.py`


------
https://chatgpt.com/codex/tasks/task_e_684e14494f108324ba55b9ea182b7d41